### PR TITLE
Update sdk contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,11 +97,5 @@
             "allow-contrib": false,
             "require": "5.3.*"
         }
-    },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/spryker-sdk/sdk-contracts"
-        }
-    ]
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2aeea06697d4d1de0cb5fd945f2dcf99",
+    "content-hash": "37033628876947fcf5299d038808f356",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -3159,8 +3159,14 @@
             "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/spryker-sdk/sdk-contracts",
-                "reference": "57a3ab60ef8f517e9752ae2112c4a56ccc4ec220"
+                "url": "https://github.com/spryker-sdk/sdk-contracts.git",
+                "reference": "ae2c92217be7744c626d08bb59cae7315200eb94"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker-sdk/sdk-contracts/zipball/ae2c92217be7744c626d08bb59cae7315200eb94",
+                "reference": "ae2c92217be7744c626d08bb59cae7315200eb94",
+                "shasum": ""
             },
             "require": {
                 "php": ">= 8.0"
@@ -3176,22 +3182,16 @@
                     "SprykerSdk\\SdkContracts\\": "src/"
                 }
             },
-            "scripts": {
-                "cs-check": [
-                    "phpcs --colors -p -s --extensions=php --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml src/"
-                ],
-                "cs-fix": [
-                    "phpcbf --colors -p --extensions=php --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml src/"
-                ],
-                "stan": [
-                    "phpstan analyze -l 8 src/"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "proprietary"
             ],
             "description": "Contracts to extend the Spryker SDK",
-            "time": "2021-12-16T06:28:05+00:00"
+            "support": {
+                "issues": "https://github.com/spryker-sdk/sdk-contracts/issues",
+                "source": "https://github.com/spryker-sdk/sdk-contracts/tree/master"
+            },
+            "time": "2021-12-17T05:52:59+00:00"
         },
         {
             "name": "spryker-sdk/spryk",


### PR DESCRIPTION
Removed manual repository mapping from composer as the spryker-sdk/sdk-contracts are available via packagist by now