### PR TITLE
SDK-647 Mapped cache directory to the image

### DIFF
--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     volumes:
       - $PWD:/project:rw
       - ./db:/data/db:rw
+      - ./var:/data/var:rw
       - ./extension:/data/extension:rw
       - ./VERSION:/data/VERSION:rw
 volumes:

--- a/build/infrastructure/sdk.Dockerfile
+++ b/build/infrastructure/sdk.Dockerfile
@@ -40,7 +40,8 @@ RUN --mount=type=cache,id=composer,sharing=locked,target=/home/spryker/.composer
   composer dump-autoload -o
 ENV APP_ENV=prod
 
-RUN bin/console sdk:init:sdk && \
-    bin/console cache:warmup
+RUN bin/console cache:warmup && \
+    bin/console sdk:init:sdk && \
+    bin/console sdk:update:all
 
 ENTRYPOINT ["/bin/bash", "-c", "/data/bin/console $@", "--"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     volumes:
       - $PWD:/project:rw
       - ./db:/data/db:rw
+      - ./var:/data/var:rw
       - ./extension:/data/extension:rw
       - ./VERSION:/data/VERSION:rw
       - ./config/packages/workflow.yaml:/data/config/packages/workflow.yaml:rw

--- a/infrastructure/create_release.sh
+++ b/infrastructure/create_release.sh
@@ -19,6 +19,7 @@ mkdir -p "${BUILD_DIR}/config/packages/"
 cp "${CURRENT_DIR}/config/packages/workflow.yaml" "${BUILD_DIR}/config/packages/workflow.yaml"
 
 mkdir -p "${BUILD_DIR}/db"
+mkdir -p "${BUILD_DIR}/var"
 cp -R "${CURRENT_DIR}/extension" "${BUILD_DIR}/"
 cp "${CURRENT_DIR}/infrastructure/sdk.Dockerfile" "${BUILD_DIR}/infrastructure/sdk.Dockerfile"
 cp "${CURRENT_DIR}/infrastructure/sdk.local.Dockerfile" "${BUILD_DIR}/infrastructure/sdk.local.Dockerfile"

--- a/infrastructure/sdk.Dockerfile
+++ b/infrastructure/sdk.Dockerfile
@@ -42,6 +42,7 @@ ENV APP_ENV=prod
 
 RUN bin/console cache:warmup && \
     bin/console sdk:init:sdk && \
-    bin/console sdk:update:all
+    bin/console sdk:update:all && \
+    bin/console cache:clear
 
 ENTRYPOINT ["/bin/bash", "-c", "/data/bin/console $@", "--"]

--- a/infrastructure/sdk.Dockerfile
+++ b/infrastructure/sdk.Dockerfile
@@ -42,7 +42,6 @@ ENV APP_ENV=prod
 
 RUN bin/console cache:warmup && \
     bin/console sdk:init:sdk && \
-    bin/console sdk:update:all && \
-    bin/console cache:clear
+    bin/console sdk:update:all
 
 ENTRYPOINT ["/bin/bash", "-c", "/data/bin/console $@", "--"]

--- a/src/Presentation/Console/Commands/InitSdkCommand.php
+++ b/src/Presentation/Console/Commands/InitSdkCommand.php
@@ -104,9 +104,9 @@ class InitSdkCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->clearCache($output);
         $this->initializeSettingValues($input->getOptions(), $this->readSettingDefinitions());
         $this->taskManager->initialize($this->taskYamlRepository->findAll());
-        $this->clearCache($output);
 
         return static::SUCCESS;
     }
@@ -251,6 +251,7 @@ class InitSdkCommand extends Command
             return;
         }
 
+        $app->setAutoExit(false);
         $app->run(new ArrayInput(['command' => 'cache:clear']), $output);
     }
 }

--- a/src/Presentation/Console/Commands/InitSdkCommand.php
+++ b/src/Presentation/Console/Commands/InitSdkCommand.php
@@ -106,6 +106,7 @@ class InitSdkCommand extends Command
     {
         $this->initializeSettingValues($input->getOptions(), $this->readSettingDefinitions());
         $this->taskManager->initialize($this->taskYamlRepository->findAll());
+        $this->clearCache($output);
 
         return static::SUCCESS;
     }
@@ -235,5 +236,21 @@ class InitSdkCommand extends Command
         $migrationInput = new ArrayInput(['allow-no-migration']);
         $migrationInput->setInteractive(false);
         $this->doctrineMigrationCommand->run($migrationInput, new NullOutput());
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
+     * @return void
+     */
+    protected function clearCache(OutputInterface $output): void
+    {
+        $app = $this->getApplication();
+
+        if (!$app) {
+            return;
+        }
+
+        $app->run(new ArrayInput(['command' => 'cache:clear']), $output);
     }
 }

--- a/src/Presentation/Console/Commands/UpdateCommand.php
+++ b/src/Presentation/Console/Commands/UpdateCommand.php
@@ -84,15 +84,15 @@ class UpdateCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if ($input->getOption(static::OPTION_NO_CHECK) !== null) {
-            $this->checkForUpdate($output);
-        }
+        $this->clearCache($output);
+
+//        if ($input->getOption(static::OPTION_NO_CHECK) !== null) {
+//            $this->checkForUpdate($output);
+//        }
 
         if ($input->getOption(static::OPTION_CHECK_ONLY) !== null) {
             $this->lifecycleManager->update();
         }
-
-        $this->clearCache($output);
 
         return static::SUCCESS;
     }
@@ -186,6 +186,7 @@ class UpdateCommand extends Command
             return;
         }
 
+        $app->setAutoExit(false);
         $app->run(new ArrayInput(['command' => 'cache:clear']), $output);
     }
 }

--- a/src/Presentation/Console/Commands/UpdateCommand.php
+++ b/src/Presentation/Console/Commands/UpdateCommand.php
@@ -9,7 +9,7 @@ namespace SprykerSdk\Sdk\Presentation\Console\Commands;
 
 use SprykerSdk\Sdk\Core\Appplication\Dependency\LifecycleManagerInterface;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\ProcessHelper;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -37,24 +37,19 @@ class UpdateCommand extends Command
      */
     protected static $defaultDescription = 'Update Spryker SDK to latest version.';
 
-    protected ProcessHelper $processHelper;
-
     protected LifecycleManagerInterface $lifecycleManager;
 
     protected string $sdkDirectory;
 
     /**
-     * @param \Symfony\Component\Console\Helper\ProcessHelper $processHelper
      * @param \SprykerSdk\Sdk\Core\Appplication\Dependency\LifecycleManagerInterface $lifecycleManager
      * @param string $sdkDirectory
      */
     public function __construct(
-        ProcessHelper $processHelper,
         LifecycleManagerInterface $lifecycleManager,
         string $sdkDirectory
     ) {
         parent::__construct(static::$defaultName);
-        $this->processHelper = $processHelper;
         $this->lifecycleManager = $lifecycleManager;
         $this->sdkDirectory = $sdkDirectory;
     }
@@ -96,6 +91,8 @@ class UpdateCommand extends Command
         if ($input->getOption(static::OPTION_CHECK_ONLY) !== null) {
             $this->lifecycleManager->update();
         }
+
+        $this->clearCache($output);
 
         return static::SUCCESS;
     }
@@ -174,5 +171,21 @@ class UpdateCommand extends Command
         }
 
         return $githubContent['tag_name'] ?? '0.0.0';
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
+     * @return void
+     */
+    protected function clearCache(OutputInterface $output): void
+    {
+        $app = $this->getApplication();
+
+        if (!$app) {
+            return;
+        }
+
+        $app->run(new ArrayInput(['command' => 'cache:clear']), $output);
     }
 }

--- a/src/Presentation/Console/Resources/config/services.yaml
+++ b/src/Presentation/Console/Resources/config/services.yaml
@@ -42,7 +42,6 @@ services:
     class: SprykerSdk\Sdk\Presentation\Console\Commands\UpdateCommand
     tags: ["console.command"]
     arguments:
-      - "@process_helper"
       - "@service.lifecycle_manager"
       - "%kernel.project_dir%"
 


### PR DESCRIPTION
The only way to automatically invalidate container cache in prod env is to enable debug mode: [http-kernel/Kernel.php:438](https://github.com/symfony/http-kernel/blob/6.1/Kernel.php#L438) -> [config/ConfigCache.php:49](https://github.com/symfony/config/blob/6.1/ConfigCache.php#L49) 

It was decided to map cache cache dir into container to allow users to manage cache themselves.