### PR TITLE
APPS-4764 Added depth to not clone the whole history.

### DIFF
--- a/build/extension/SprykerSdk/SdkTasksBundle/Task/Command/CloneInternalProjectRepositoryCommand.php
+++ b/build/extension/SprykerSdk/SdkTasksBundle/Task/Command/CloneInternalProjectRepositoryCommand.php
@@ -19,7 +19,7 @@ class CloneInternalProjectRepositoryCommand implements CommandInterface, ErrorCo
      */
     public function getCommand(): string
     {
-        return 'git clone %internal_project_url% --single-branch ./';
+        return 'git clone %internal_project_url% --single-branch --depth=1 ./';
     }
 
     /**


### PR DESCRIPTION
Use `--depth=1` to not clone the whole history.