### PR TITLE
Update Upgrader tool inside SDK

### DIFF
--- a/bin/spryker-sdk.sh
+++ b/bin/spryker-sdk.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-MODE='prod'
-
 SDK_DIR="$(dirname $(dirname $0))"
+
+if [[ $# == 1 && ($@ == "--version" || $@ == "-V") ]]; then
+    cat $SDK_DIR/VERSION
+    exit 0
+fi
+
+MODE='prod'
 
 ARGUMENTS=""
 

--- a/composer.lock
+++ b/composer.lock
@@ -6446,12 +6446,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-sdk/upgrader.git",
-                "reference": "069631f862d1997010c0cd84fa88f1952b9ff9c2"
+                "reference": "f15a2aabdabaa0cc9137ca4a15de2a76d82e7386"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-sdk/upgrader/zipball/069631f862d1997010c0cd84fa88f1952b9ff9c2",
-                "reference": "069631f862d1997010c0cd84fa88f1952b9ff9c2",
+                "url": "https://api.github.com/repos/spryker-sdk/upgrader/zipball/f15a2aabdabaa0cc9137ca4a15de2a76d82e7386",
+                "reference": "f15a2aabdabaa0cc9137ca4a15de2a76d82e7386",
                 "shasum": ""
             },
             "require": {
@@ -6508,7 +6508,7 @@
                 "issues": "https://github.com/spryker-sdk/upgrader/issues",
                 "source": "https://github.com/spryker-sdk/upgrader/tree/master"
             },
-            "time": "2022-10-04T09:19:16+00:00"
+            "time": "2022-10-05T15:13:56+00:00"
         },
         {
             "name": "spryker/architecture-sniffer",

--- a/composer.lock
+++ b/composer.lock
@@ -6446,12 +6446,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-sdk/upgrader.git",
-                "reference": "d9ff6014705d8311ba82ccfec553dc6a4499976e"
+                "reference": "069631f862d1997010c0cd84fa88f1952b9ff9c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-sdk/upgrader/zipball/d9ff6014705d8311ba82ccfec553dc6a4499976e",
-                "reference": "d9ff6014705d8311ba82ccfec553dc6a4499976e",
+                "url": "https://api.github.com/repos/spryker-sdk/upgrader/zipball/069631f862d1997010c0cd84fa88f1952b9ff9c2",
+                "reference": "069631f862d1997010c0cd84fa88f1952b9ff9c2",
                 "shasum": ""
             },
             "require": {
@@ -6508,7 +6508,7 @@
                 "issues": "https://github.com/spryker-sdk/upgrader/issues",
                 "source": "https://github.com/spryker-sdk/upgrader/tree/master"
             },
-            "time": "2022-09-27T07:30:17+00:00"
+            "time": "2022-10-04T09:19:16+00:00"
         },
         {
             "name": "spryker/architecture-sniffer",
@@ -14454,5 +14454,5 @@
         "composer-runtime-api": "^2.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Following functionality is delivered to SDK with this update: 

[PPLUS-1393](https://spryker.atlassian.net/browse/PPLUS-1393): Add new evaluator rule to check if the module name is unique
[PPLUS-1341](https://spryker.atlassian.net/browse/PPLUS-1341): Add support of strict order for plugins inside of manifest file
[PPLUS-1476](https://spryker.atlassian.net/browse/PPLUS-1476): Improvement of integrator to cover more manifest scenarios
[PPLUS-1624](https://spryker.atlassian.net/browse/PPLUS-1624): Fix the errors in data output in evaluator report
[PPLUS-1619](https://spryker.atlassian.net/browse/PPLUS-1619): Fix the bug with the wrong exit status code in upgrader command
[PPLUS-1591](https://spryker.atlassian.net/browse/PPLUS-1591): Output links on documentation for evaluator output