### PR TITLE
Allow linux/arm64 arch in docker build github action

### DIFF
--- a/.github/workflows/docker.build.yml
+++ b/.github/workflows/docker.build.yml
@@ -15,7 +15,7 @@ jobs:
                 include:
                     - image: 'infrastructure/sdk.Dockerfile'
                       tags: [ 'php-sdk:latest' ]
-                      platforms: [ "linux/amd64" ]
+                      platforms: [ "linux/amd64", "linux/arm64" ]
         steps:
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v1

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -27,7 +27,7 @@ jobs:
                 with:
                     context: .
                     file: ./infrastructure/sdk.Dockerfile
-                    platforms: linux/amd64
+                    platforms: linux/amd64,linux/arm64
                     push: true
                     tags: spryker/php-sdk:${{ github.event.release.tag_name }}
                     labels: Release ${{ github.event.release.tag_name }}


### PR DESCRIPTION
With this PR I would allow the spryker-sdk/sdk to create also a docker image for arm64 architecture.