### PR TITLE
Useless command if AddModule spryk is used

### DIFF
--- a/src/Extension/Resources/config/task/SprykAddModuleTask.yaml
+++ b/src/Extension/Resources/config/task/SprykAddModuleTask.yaml
@@ -3,7 +3,7 @@ id: "generate:php:add-module"
 short_description: "Generate a new Spryker module in the current project"
 help: ~
 stage: build
-command: "php %sdk_dir%/vendor/bin/spryk-run AddModule %organization% %coreLevel% %module%"
+command: "php %sdk_dir%/vendor/bin/spryk-run AddModuleDefault %organization% %coreLevel% %module%"
 version: 1.1.1
 type: !php/const SprykerSdk\SdkContracts\Enum\Task::TYPE_LOCAL_CLI
 placeholders:

--- a/src/Extension/Resources/config/task/SprykAddModuleTask.yaml
+++ b/src/Extension/Resources/config/task/SprykAddModuleTask.yaml
@@ -4,7 +4,7 @@ short_description: "Generate a new Spryker module in the current project"
 help: ~
 stage: build
 command: "php %sdk_dir%/vendor/bin/spryk-run AddModuleDefault %organization% %coreLevel% %module%"
-version: 1.1.1
+version: 1.1.2
 type: !php/const SprykerSdk\SdkContracts\Enum\Task::TYPE_LOCAL_CLI
 placeholders:
   - name: "%sdk_dir%"


### PR DESCRIPTION
After starting to play with the SDK I was in this case mostly interested in testing how it can be used for generating basic module code so development performance can be improved.  

After running the command `spryker-sdk generate:php:add-module --module=VisaPayment --namespace=Pyz -vvv` the only result is that in best case one folder is created, nothing awesome I would say.

If instead of using the `AddModule`, `AddModuleDefault` is used, real boilerplate code is being generated e.g. Shared and Zed module directories, transfer objects definition file, Zed Config and DependencyProvider, Facade. Entity Manager and repository.

With this change, the command can add some value to our Spryker developers during development.